### PR TITLE
Urgent wish action space : birth

### DIFF
--- a/domain/actionUtils.ts
+++ b/domain/actionUtils.ts
@@ -32,6 +32,9 @@ export namespace ActionUtils {
         const newDwarf = new Dwarf();
         const newPlayerDwarfs = new Map(player.dwarfs);
         newPlayerDwarfs.set(newDwarf.id, newDwarf);
-        return [{ original: player, diff: { dwarfs: newPlayerDwarfs } }];
+        return [
+            { original: player, diff: { dwarfs: newPlayerDwarfs } },
+            { original: actionSpace, diff: { newBornDwarf: newDwarf } },
+        ];
     }
 }

--- a/domain/actionUtils.ts
+++ b/domain/actionUtils.ts
@@ -30,6 +30,7 @@ export namespace ActionUtils {
         player: Player
     ): EntityMutation<EntityType>[] {
         const newDwarf = new Dwarf();
+        newDwarf.isAvailable = false;
         const newPlayerDwarfs = new Map(player.dwarfs);
         newPlayerDwarfs.set(newDwarf.id, newDwarf);
         return [

--- a/domain/actionUtils.ts
+++ b/domain/actionUtils.ts
@@ -1,6 +1,6 @@
 import { ActionSpace } from "./entity/ActionSpace";
-import { Player } from "./entity/Player";
 import { EntityMutation, EntityType } from "./entity/Mutation";
+import { Dwarf, Player } from "./entity/Player";
 import { Resources } from "./entity/Resources";
 
 export namespace ActionUtils {
@@ -23,5 +23,15 @@ export namespace ActionUtils {
             { original: actionSpace, diff: { resources: new Resources() } },
             { original: player, diff: { resources: player.resources.add(actionSpace.resources) } },
         ];
+    }
+
+    export function giveBirthToDwarf(
+        actionSpace: ActionSpace,
+        player: Player
+    ): EntityMutation<EntityType>[] {
+        const newDwarf = new Dwarf();
+        const newPlayerDwarfs = new Map(player.dwarfs);
+        newPlayerDwarfs.set(newDwarf.id, newDwarf);
+        return [{ original: player, diff: { dwarfs: newPlayerDwarfs } }];
     }
 }

--- a/domain/entity/ActionSpace.ts
+++ b/domain/entity/ActionSpace.ts
@@ -4,10 +4,17 @@ import { Game } from "./Game";
 import { Resources } from "./Resources";
 
 export class ActionSpace {
-    constructor(id: ActionSpaceId, action: Action, replenishment?: Replenishment, dwarf?: Dwarf) {
+    constructor(
+        id: ActionSpaceId,
+        action: Action,
+        replenishment?: Replenishment,
+        dwarf?: Dwarf,
+        newBornDwarf?: Dwarf
+    ) {
         this.id = id;
         this.action = action;
         this.dwarf = dwarf;
+        this.newBornDwarf = newBornDwarf;
         this.resources = new Resources();
         this.replenishment = replenishment;
     }
@@ -15,6 +22,7 @@ export class ActionSpace {
     id: ActionSpaceId;
     action: Action;
     dwarf?: Dwarf;
+    newBornDwarf?: Dwarf;
     resources: Resources;
     replenishment?: Replenishment;
 }

--- a/domain/entity/ActionSpace.ts
+++ b/domain/entity/ActionSpace.ts
@@ -21,6 +21,7 @@ export class ActionSpace {
 
 export enum ActionSpaceId {
     GATHER_WOOD = "gather_wood",
+    URGENT_WISH_FOR_CHILDREN = "urgent_wish_for_children",
 }
 
 export type Action = (game: Game, playerId: PlayerId) => EntityMutation<EntityType>[];

--- a/domain/entity/Furnishing.ts
+++ b/domain/entity/Furnishing.ts
@@ -1,0 +1,15 @@
+import { Resources } from "./Resources";
+
+export class Furnishing {
+    constructor(id: FurnishingId, price: Resources) {
+        this.id = id;
+        this.price = price;
+    }
+
+    id: FurnishingId;
+    price: Resources;
+}
+
+export enum FurnishingId {
+    DWELLING = "dwelling",
+}

--- a/domain/entity/Mutation.ts
+++ b/domain/entity/Mutation.ts
@@ -17,7 +17,7 @@ type DiscriminateUnion<T> = T extends any ? Mutation<T> : never;
 // To fix that, we create a new type with an intersection to exclude Mutation<EntityType>
 export type EntityMutation<T> = DiscriminateUnion<EntityType> & Mutation<T>;
 
-export function isMutationOfType<T extends EntityType>(classType: { new (): T }) {
+export function isMutationOfType<T extends EntityType>(classType: { new (...arg: any): T }) {
     return function (mutation: EntityMutation<EntityType>): mutation is EntityMutation<T> {
         return mutation.original instanceof classType;
     };

--- a/domain/furnishing/dwelling.ts
+++ b/domain/furnishing/dwelling.ts
@@ -1,0 +1,13 @@
+import { Resources, ResourceType } from "../entity/Resources";
+import { Furnishing, FurnishingId } from "../entity/Furnishing";
+
+export namespace Dwelling {
+    const PRICE = new Resources([
+        [ResourceType.WOOD, 4],
+        [ResourceType.STONE, 3],
+    ]);
+
+    export function createFurnishing(): Furnishing {
+        return new Furnishing(FurnishingId.DWELLING, PRICE);
+    }
+}

--- a/domain/initializeGame.ts
+++ b/domain/initializeGame.ts
@@ -1,13 +1,17 @@
 import { GatherWood } from "./gatherWood";
 import { ActionBoard, Game } from "./entity/Game";
 import { Dwarf, Player } from "./entity/Player";
+import { UrgentWishForChildren } from "./urgentWishForChildren";
 
 export function buildInitialGame(): Game {
     return new Game(buildInitialActionBoard(), [buildInitialPlayer()]);
 }
 
 export function buildInitialActionBoard() {
-    return new ActionBoard([GatherWood.createActionSpace()]);
+    return new ActionBoard([
+        GatherWood.createActionSpace(),
+        UrgentWishForChildren.createActionSpace(),
+    ]);
 }
 
 export function buildInitialPlayer(): Player {

--- a/domain/urgentWishForChildren.ts
+++ b/domain/urgentWishForChildren.ts
@@ -9,7 +9,10 @@ export namespace UrgentWishForChildren {
         const actionSpaceId = ActionSpaceId.URGENT_WISH_FOR_CHILDREN;
         const player = game.getPlayer(playerId);
         const actionSpace = game.actionBoard.getActionSpace(actionSpaceId);
-        return [...ActionUtils.bookActionSpace(actionSpace, player)];
+        return [
+            ...ActionUtils.bookActionSpace(actionSpace, player),
+            ...ActionUtils.giveBirthToDwarf(actionSpace, player),
+        ];
     }
 
     export function createActionSpace() {

--- a/domain/urgentWishForChildren.ts
+++ b/domain/urgentWishForChildren.ts
@@ -1,0 +1,18 @@
+import { PlayerId } from "./entity/Player";
+import { EntityType, EntityMutation } from "./entity/Mutation";
+import { Game } from "./entity/Game";
+import { ActionSpace, ActionSpaceId } from "./entity/ActionSpace";
+import { ActionUtils } from "./actionUtils";
+
+export namespace UrgentWishForChildren {
+    export function execute(game: Game, playerId: PlayerId): EntityMutation<EntityType>[] {
+        const actionSpaceId = ActionSpaceId.URGENT_WISH_FOR_CHILDREN;
+        const player = game.getPlayer(playerId);
+        const actionSpace = game.actionBoard.getActionSpace(actionSpaceId);
+        return [...ActionUtils.bookActionSpace(actionSpace, player)];
+    }
+
+    export function createActionSpace() {
+        return new ActionSpace(ActionSpaceId.URGENT_WISH_FOR_CHILDREN, execute);
+    }
+}

--- a/domain/urgentWishForChildren.unit.ts
+++ b/domain/urgentWishForChildren.unit.ts
@@ -1,7 +1,8 @@
 import { buildBaseObjects, expectMutationsOfType, shouldPlaceDwarf } from "./testUtils";
 import { UrgentWishForChildren } from "./urgentWishForChildren";
-import { Player } from "./entity/Player";
+import { Dwarf, Player } from "./entity/Player";
 import { ActionSpace } from "./entity/ActionSpace";
+import { Mutation } from "./entity/Mutation";
 
 describe("Urgent Wish for Children", () => {
     shouldPlaceDwarf(UrgentWishForChildren.execute);
@@ -27,7 +28,39 @@ describe("Urgent Wish for Children", () => {
         );
     });
 
-    it("new dwarf should be busy", function () {});
+    describe("new dwarf should be busy", function () {
+        it("new player's dwarf should be busy", function () {
+            const { game, player } = buildBaseObjects();
+
+            const mutations = UrgentWishForChildren.execute(game, player.id);
+
+            expectMutationsOfType(mutations, Player).toVerifyOnce(
+                (mutation) => findNewDwarf(mutation, player)?.isAvailable === false
+            );
+
+            function findNewDwarf(
+                mutation: Mutation<Player>,
+                originalPlayer: Player
+            ): Dwarf | undefined {
+                const mutationDwarfs = mutation.diff.dwarfs?.values();
+                if (typeof mutationDwarfs === "undefined") return undefined;
+
+                return [...mutationDwarfs].find(
+                    (dwarf: Dwarf) => originalPlayer.dwarfs?.has(dwarf.id) === false
+                );
+            }
+        });
+
+        it("new action space dwarf should be busy", function () {
+            const { game, player } = buildBaseObjects();
+
+            const mutations = UrgentWishForChildren.execute(game, player.id);
+
+            expectMutationsOfType(mutations, ActionSpace).toVerifyOnce(
+                (mutation) => mutation.diff.newBornDwarf?.isAvailable === false
+            );
+        });
+    });
 
     it("should pay for dwelling", function () {});
 

--- a/domain/urgentWishForChildren.unit.ts
+++ b/domain/urgentWishForChildren.unit.ts
@@ -2,7 +2,8 @@ import { buildBaseObjects, expectMutationsOfType, shouldPlaceDwarf } from "./tes
 import { UrgentWishForChildren } from "./urgentWishForChildren";
 import { Dwarf, Player } from "./entity/Player";
 import { ActionSpace } from "./entity/ActionSpace";
-import { Mutation } from "./entity/Mutation";
+import { EntityMutation, isMutationOfType } from "./entity/Mutation";
+import { expect } from "chai";
 
 describe("Urgent Wish for Children", () => {
     shouldPlaceDwarf(UrgentWishForChildren.execute);
@@ -28,6 +29,26 @@ describe("Urgent Wish for Children", () => {
         );
     });
 
+    it("New dwarf should be the same for player and action space", function () {
+        const { game, player } = buildBaseObjects();
+
+        const mutations = UrgentWishForChildren.execute(game, player.id);
+
+        const actionSpaceMutation = mutations
+            .filter(isMutationOfType(ActionSpace))
+            .filter((mutation) => mutation.diff.newBornDwarf)[0];
+        const playerMutation = mutations
+            .filter(isMutationOfType(Player))
+            .filter((mutation) => mutation.diff.dwarfs)[0];
+
+        const actionSpaceDwarf = actionSpaceMutation?.diff?.newBornDwarf;
+        const playerDwarf = findNewDwarf(playerMutation, player);
+
+        expect(playerDwarf).to.exist;
+        expect(actionSpaceMutation).to.exist;
+        expect(actionSpaceDwarf).to.deep.equal(playerDwarf);
+    });
+
     describe("new dwarf should be busy", function () {
         it("new player's dwarf should be busy", function () {
             const { game, player } = buildBaseObjects();
@@ -37,18 +58,6 @@ describe("Urgent Wish for Children", () => {
             expectMutationsOfType(mutations, Player).toVerifyOnce(
                 (mutation) => findNewDwarf(mutation, player)?.isAvailable === false
             );
-
-            function findNewDwarf(
-                mutation: Mutation<Player>,
-                originalPlayer: Player
-            ): Dwarf | undefined {
-                const mutationDwarfs = mutation.diff.dwarfs?.values();
-                if (typeof mutationDwarfs === "undefined") return undefined;
-
-                return [...mutationDwarfs].find(
-                    (dwarf: Dwarf) => originalPlayer.dwarfs?.has(dwarf.id) === false
-                );
-            }
         });
 
         it("new action space dwarf should be busy", function () {
@@ -61,6 +70,15 @@ describe("Urgent Wish for Children", () => {
             );
         });
     });
+
+    function findNewDwarf(mutation: EntityMutation<Player>, originalPlayer: Player): Dwarf | undefined {
+        const mutationDwarfs = mutation.diff.dwarfs?.values();
+        if (typeof mutationDwarfs === "undefined") return undefined;
+
+        return [...mutationDwarfs].find(
+            (dwarf: Dwarf) => originalPlayer.dwarfs?.has(dwarf.id) === false
+        );
+    }
 
     it("should pay for dwelling", function () {});
 

--- a/domain/urgentWishForChildren.unit.ts
+++ b/domain/urgentWishForChildren.unit.ts
@@ -1,0 +1,14 @@
+import { shouldPlaceDwarf } from "./testUtils";
+import { UrgentWishForChildren } from "./urgentWishForChildren";
+
+describe("Urgent Wish for Children", () => {
+    shouldPlaceDwarf(UrgentWishForChildren.execute);
+
+    it("should add new dwarf to action space", function () {});
+
+    it("new dwarf should be busy", function () {});
+
+    it("should pay for dwelling", function () {});
+
+    it("should add dwelling to player's store", function () {});
+});

--- a/domain/urgentWishForChildren.unit.ts
+++ b/domain/urgentWishForChildren.unit.ts
@@ -1,8 +1,20 @@
-import { shouldPlaceDwarf } from "./testUtils";
+import { buildBaseObjects, expectMutationsOfType, shouldPlaceDwarf } from "./testUtils";
 import { UrgentWishForChildren } from "./urgentWishForChildren";
+import { Player } from "./entity/Player";
 
 describe("Urgent Wish for Children", () => {
     shouldPlaceDwarf(UrgentWishForChildren.execute);
+
+    it("should add new dwarf to player", function () {
+        const { game, player } = buildBaseObjects();
+        const playerInitialDwarfsNb = player.dwarfs.size;
+
+        const mutations = UrgentWishForChildren.execute(game, player.id);
+
+        expectMutationsOfType(mutations, Player).toVerifyOnce(
+            (mutation) => mutation.diff.dwarfs?.size === playerInitialDwarfsNb + 1
+        );
+    });
 
     it("should add new dwarf to action space", function () {});
 

--- a/domain/urgentWishForChildren.unit.ts
+++ b/domain/urgentWishForChildren.unit.ts
@@ -8,77 +8,81 @@ import { expect } from "chai";
 describe("Urgent Wish for Children", () => {
     shouldPlaceDwarf(UrgentWishForChildren.execute);
 
-    it("should add new dwarf to player", function () {
-        const { game, player } = buildBaseObjects();
-        const playerInitialDwarfsNb = player.dwarfs.size;
-
-        const mutations = UrgentWishForChildren.execute(game, player.id);
-
-        expectMutationsOfType(mutations, Player).toVerifyOnce(
-            (mutation) => mutation.diff.dwarfs?.size === playerInitialDwarfsNb + 1
-        );
-    });
-
-    it("should add new dwarf to action space", function () {
-        const { game, player } = buildBaseObjects();
-
-        const mutations = UrgentWishForChildren.execute(game, player.id);
-
-        expectMutationsOfType(mutations, ActionSpace).toVerifyOnce(
-            (mutation) => !!mutation.diff.newBornDwarf
-        );
-    });
-
-    it("New dwarf should be the same for player and action space", function () {
-        const { game, player } = buildBaseObjects();
-
-        const mutations = UrgentWishForChildren.execute(game, player.id);
-
-        const actionSpaceMutation = mutations
-            .filter(isMutationOfType(ActionSpace))
-            .filter((mutation) => mutation.diff.newBornDwarf)[0];
-        const playerMutation = mutations
-            .filter(isMutationOfType(Player))
-            .filter((mutation) => mutation.diff.dwarfs)[0];
-
-        const actionSpaceDwarf = actionSpaceMutation?.diff?.newBornDwarf;
-        const playerDwarf = findNewDwarf(playerMutation, player);
-
-        expect(playerDwarf).to.exist;
-        expect(actionSpaceMutation).to.exist;
-        expect(actionSpaceDwarf).to.deep.equal(playerDwarf);
-    });
-
-    describe("new dwarf should be busy", function () {
-        it("new player's dwarf should be busy", function () {
+    describe("should create and place a new dwarf", () => {
+        it("should add new dwarf to player", function () {
             const { game, player } = buildBaseObjects();
+            const playerInitialDwarfsNb = player.dwarfs.size;
 
             const mutations = UrgentWishForChildren.execute(game, player.id);
 
             expectMutationsOfType(mutations, Player).toVerifyOnce(
-                (mutation) => findNewDwarf(mutation, player)?.isAvailable === false
+                (mutation) => mutation.diff.dwarfs?.size === playerInitialDwarfsNb + 1
             );
         });
 
-        it("new action space dwarf should be busy", function () {
+        it("should add new dwarf to action space", function () {
             const { game, player } = buildBaseObjects();
 
             const mutations = UrgentWishForChildren.execute(game, player.id);
 
             expectMutationsOfType(mutations, ActionSpace).toVerifyOnce(
-                (mutation) => mutation.diff.newBornDwarf?.isAvailable === false
+                (mutation) => !!mutation.diff.newBornDwarf
             );
         });
+
+        it("new dwarf should be the same for player and action space", function () {
+            const { game, player } = buildBaseObjects();
+
+            const mutations = UrgentWishForChildren.execute(game, player.id);
+
+            const actionSpaceMutation = mutations
+                .filter(isMutationOfType(ActionSpace))
+                .filter((mutation) => mutation.diff.newBornDwarf)[0];
+            const playerMutation = mutations
+                .filter(isMutationOfType(Player))
+                .filter((mutation) => mutation.diff.dwarfs)[0];
+
+            const actionSpaceDwarf = actionSpaceMutation?.diff?.newBornDwarf;
+            const playerDwarf = findNewDwarf(playerMutation, player);
+
+            expect(playerDwarf).to.exist;
+            expect(actionSpaceMutation).to.exist;
+            expect(actionSpaceDwarf).to.deep.equal(playerDwarf);
+        });
+
+        describe("new dwarf should be busy", function () {
+            it("new player's dwarf should be busy", function () {
+                const { game, player } = buildBaseObjects();
+
+                const mutations = UrgentWishForChildren.execute(game, player.id);
+
+                expectMutationsOfType(mutations, Player).toVerifyOnce(
+                    (mutation) => findNewDwarf(mutation, player)?.isAvailable === false
+                );
+            });
+
+            it("new action space dwarf should be busy", function () {
+                const { game, player } = buildBaseObjects();
+
+                const mutations = UrgentWishForChildren.execute(game, player.id);
+
+                expectMutationsOfType(mutations, ActionSpace).toVerifyOnce(
+                    (mutation) => mutation.diff.newBornDwarf?.isAvailable === false
+                );
+            });
+        });
+
+        function findNewDwarf(
+            mutation: EntityMutation<Player>,
+            originalPlayer: Player
+        ): Dwarf | undefined {
+            const mutationDwarfs = mutation.diff.dwarfs?.values();
+            if (typeof mutationDwarfs === "undefined") return undefined;
+            return [...mutationDwarfs].find(
+                (dwarf: Dwarf) => originalPlayer.dwarfs?.has(dwarf.id) === false
+            );
+        }
     });
-
-    function findNewDwarf(mutation: EntityMutation<Player>, originalPlayer: Player): Dwarf | undefined {
-        const mutationDwarfs = mutation.diff.dwarfs?.values();
-        if (typeof mutationDwarfs === "undefined") return undefined;
-
-        return [...mutationDwarfs].find(
-            (dwarf: Dwarf) => originalPlayer.dwarfs?.has(dwarf.id) === false
-        );
-    }
 
     it("should pay for dwelling", function () {});
 

--- a/domain/urgentWishForChildren.unit.ts
+++ b/domain/urgentWishForChildren.unit.ts
@@ -2,7 +2,7 @@ import { buildBaseObjects, expectMutationsOfType, shouldPlaceDwarf } from "./tes
 import { UrgentWishForChildren } from "./urgentWishForChildren";
 import { Dwarf, Player } from "./entity/Player";
 import { ActionSpace } from "./entity/ActionSpace";
-import { EntityMutation, isMutationOfType } from "./entity/Mutation";
+import { EntityMutation, EntityType, isMutationOfType } from "./entity/Mutation";
 import { expect } from "chai";
 
 describe("Urgent Wish for Children", () => {
@@ -35,20 +35,26 @@ describe("Urgent Wish for Children", () => {
 
             const mutations = UrgentWishForChildren.execute(game, player.id);
 
+            const actionSpaceDwarf = getActionSpaceNewDwarf(mutations);
+            const playerDwarf = getPlayerNewDwarf(mutations, player);
+
+            expect(actionSpaceDwarf).to.deep.equal(playerDwarf);
+        });
+
+        function getActionSpaceNewDwarf(mutations: EntityMutation<EntityType>[]) {
             const actionSpaceMutation = mutations
                 .filter(isMutationOfType(ActionSpace))
                 .filter((mutation) => mutation.diff.newBornDwarf)[0];
+            return actionSpaceMutation?.diff?.newBornDwarf;
+        }
+
+        function getPlayerNewDwarf(mutations: EntityMutation<EntityType>[], player: Player) {
             const playerMutation = mutations
                 .filter(isMutationOfType(Player))
                 .filter((mutation) => mutation.diff.dwarfs)[0];
 
-            const actionSpaceDwarf = actionSpaceMutation?.diff?.newBornDwarf;
-            const playerDwarf = findNewDwarf(playerMutation, player);
-
-            expect(playerDwarf).to.exist;
-            expect(actionSpaceMutation).to.exist;
-            expect(actionSpaceDwarf).to.deep.equal(playerDwarf);
-        });
+            return findNewDwarf(playerMutation, player);
+        }
 
         describe("new dwarf should be busy", function () {
             it("new player's dwarf should be busy", function () {

--- a/domain/urgentWishForChildren.unit.ts
+++ b/domain/urgentWishForChildren.unit.ts
@@ -1,6 +1,7 @@
 import { buildBaseObjects, expectMutationsOfType, shouldPlaceDwarf } from "./testUtils";
 import { UrgentWishForChildren } from "./urgentWishForChildren";
 import { Player } from "./entity/Player";
+import { ActionSpace } from "./entity/ActionSpace";
 
 describe("Urgent Wish for Children", () => {
     shouldPlaceDwarf(UrgentWishForChildren.execute);
@@ -16,7 +17,15 @@ describe("Urgent Wish for Children", () => {
         );
     });
 
-    it("should add new dwarf to action space", function () {});
+    it("should add new dwarf to action space", function () {
+        const { game, player } = buildBaseObjects();
+
+        const mutations = UrgentWishForChildren.execute(game, player.id);
+
+        expectMutationsOfType(mutations, ActionSpace).toVerifyOnce(
+            (mutation) => !!mutation.diff.newBornDwarf
+        );
+    });
 
     it("new dwarf should be busy", function () {});
 


### PR DESCRIPTION
This PR implement the birth part of `urgent wish for children` action:
- Create a new dwarf for the player
- Place it on the action space
- Make the new dwarf busy

PS: not sure that the description above is totally useful since it repeats information provided by commits alreayd 🤔 wdyt?