### PR TITLE
Fix mutation 2

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
     "parser": "@typescript-eslint/parser",
     "plugins": ["@typescript-eslint", "prettier"],
     "rules": {
-        "prettier/prettier": "error"
+        "prettier/prettier": "error",
+        "@typescript-eslint/no-empty-function": "warn"
     },
     "extends": [
         "eslint:recommended",

--- a/domain/actionSpace/gatherWood.ts
+++ b/domain/actionSpace/gatherWood.ts
@@ -2,7 +2,6 @@ import {
     ActionSpace,
     ActionSpaceId,
     EntityMutation,
-    EntityType,
     Game,
     PlayerId,
     Resources,
@@ -20,7 +19,7 @@ const REPLENISH_RESOURCES = {
     ifNotEmpty: new Resources([[ResourceType.WOOD, 1]]),
 };
 
-function execute(game: Game, playerId: PlayerId): EntityMutation<EntityType>[] {
+function execute(game: Game, playerId: PlayerId): EntityMutation[] {
     const actionSpaceId = ActionSpaceId.GATHER_WOOD;
     const player = game.getPlayer(playerId);
     const actionSpace = game.actionBoard.getActionSpace(actionSpaceId);

--- a/domain/actionSpace/urgentWishForChildren.ts
+++ b/domain/actionSpace/urgentWishForChildren.ts
@@ -1,4 +1,4 @@
-import { ActionSpace, ActionSpaceId, EntityMutation, EntityType, Game, PlayerId } from "../entity";
+import { ActionSpace, ActionSpaceId, EntityMutation, Game, PlayerId } from "../entity";
 import { bookActionSpace, giveBirthToDwarf } from "./utils";
 
 export const UrgentWishForChildren = {
@@ -6,7 +6,7 @@ export const UrgentWishForChildren = {
     createActionSpace,
 };
 
-function execute(game: Game, playerId: PlayerId): EntityMutation<EntityType>[] {
+function execute(game: Game, playerId: PlayerId): EntityMutation[] {
     const actionSpaceId = ActionSpaceId.URGENT_WISH_FOR_CHILDREN;
     const player = game.getPlayer(playerId);
     const actionSpace = game.actionBoard.getActionSpace(actionSpaceId);

--- a/domain/actionSpace/urgentWishForChildren.unit.ts
+++ b/domain/actionSpace/urgentWishForChildren.unit.ts
@@ -1,13 +1,6 @@
 import { buildBaseObjects, expectMutationsOfType, shouldPlaceDwarf } from "../util";
 import { UrgentWishForChildren } from "./urgentWishForChildren";
-import {
-    ActionSpace,
-    Dwarf,
-    EntityMutation,
-    EntityType,
-    isMutationOfType,
-    Player,
-} from "../entity";
+import { ActionSpace, Dwarf, EntityMutation, isMutationOfType, Mutation, Player } from "../entity";
 import { expect } from "chai";
 
 describe("Urgent Wish for Children", () => {
@@ -46,14 +39,14 @@ describe("Urgent Wish for Children", () => {
             expect(actionSpaceDwarf).to.deep.equal(playerDwarf);
         });
 
-        function getActionSpaceNewDwarf(mutations: EntityMutation<EntityType>[]) {
+        function getActionSpaceNewDwarf(mutations: EntityMutation[]) {
             const actionSpaceMutation = mutations
                 .filter(isMutationOfType(ActionSpace))
                 .filter((mutation) => mutation.diff.newBornDwarf)[0];
             return actionSpaceMutation?.diff?.newBornDwarf;
         }
 
-        function getPlayerNewDwarf(mutations: EntityMutation<EntityType>[], player: Player) {
+        function getPlayerNewDwarf(mutations: EntityMutation[], player: Player) {
             const playerMutation = mutations
                 .filter(isMutationOfType(Player))
                 .filter((mutation) => mutation.diff.dwarfs)[0];
@@ -84,7 +77,7 @@ describe("Urgent Wish for Children", () => {
         });
 
         function findNewDwarf(
-            mutation: EntityMutation<Player>,
+            mutation: Mutation<Player>,
             originalPlayer: Player
         ): Dwarf | undefined {
             const mutationDwarfs = mutation.diff.dwarfs?.values();

--- a/domain/actionSpace/utils.ts
+++ b/domain/actionSpace/utils.ts
@@ -1,9 +1,6 @@
-import { ActionSpace, Dwarf, EntityMutation, EntityType, Player, Resources } from "../entity";
+import { ActionSpace, Dwarf, EntityMutation, Player, Resources } from "../entity";
 
-export function bookActionSpace(
-    actionSpace: ActionSpace,
-    player: Player
-): EntityMutation<EntityType>[] {
+export function bookActionSpace(actionSpace: ActionSpace, player: Player): EntityMutation[] {
     const dwarf = player.getFirstAvailableDwarf();
     return [
         { original: dwarf, diff: { isAvailable: false } },
@@ -11,20 +8,14 @@ export function bookActionSpace(
     ];
 }
 
-export function takeResources(
-    actionSpace: ActionSpace,
-    player: Player
-): EntityMutation<EntityType>[] {
+export function takeResources(actionSpace: ActionSpace, player: Player): EntityMutation[] {
     return [
         { original: actionSpace, diff: { resources: new Resources() } },
         { original: player, diff: { resources: player.resources.add(actionSpace.resources) } },
     ];
 }
 
-export function giveBirthToDwarf(
-    actionSpace: ActionSpace,
-    player: Player
-): EntityMutation<EntityType>[] {
+export function giveBirthToDwarf(actionSpace: ActionSpace, player: Player): EntityMutation[] {
     const newDwarf = new Dwarf();
     newDwarf.isAvailable = false;
     const newPlayerDwarfs = new Map(player.dwarfs);

--- a/domain/entity/ActionSpace.ts
+++ b/domain/entity/ActionSpace.ts
@@ -1,5 +1,5 @@
 import { Dwarf, PlayerId } from "./Player";
-import { EntityMutation, EntityType } from "./Mutation";
+import { EntityMutation, Mutation } from "./Mutation";
 import { Game } from "./Game";
 import { Resources } from "./Resources";
 
@@ -32,14 +32,14 @@ export enum ActionSpaceId {
     URGENT_WISH_FOR_CHILDREN = "urgent_wish_for_children",
 }
 
-export type Action = (game: Game, playerId: PlayerId) => EntityMutation<EntityType>[];
+export type Action = (game: Game, playerId: PlayerId) => EntityMutation[];
 
 export type Replenishment = {
     ifEmpty: Resources;
     ifNotEmpty: Resources;
 };
 
-export function replenish(actionSpace: ActionSpace): EntityMutation<ActionSpace>[] {
+export function replenish(actionSpace: ActionSpace): Mutation<ActionSpace>[] {
     if (typeof actionSpace.replenishment === "undefined") return [];
 
     if (actionSpace.resources.isEmpty()) {

--- a/domain/entity/Mutation.ts
+++ b/domain/entity/Mutation.ts
@@ -4,22 +4,21 @@ import { Constructor } from "../util";
 
 export type EntityType = Player | Dwarf | ActionSpace;
 
-type Mutation<T> = {
+export type Mutation<T> = {
     original: T;
     diff: Partial<T>;
 };
 
-// DiscriminateUnion<EntityType> is equivalent to Mutation<Player> | Mutation<Dwarf> | ...
+// EntityMutation is equivalent to Mutation<Player> | Mutation<Dwarf> | ...
 // It doesn't include the type Mutation<EntityType> that allows "original" and "diff" attributes of different EntityType
 type DiscriminateUnion<T> = T extends EntityType ? Mutation<T> : never;
+export type EntityMutation = DiscriminateUnion<EntityType>;
 
 // The problem is that Mutation<T> is not included in DiscriminateUnion<EntityType> because of Mutation<EntityType>
 // and so we can't use the type guard below to narrow the type of Mutation<T> (see https://github.com/microsoft/TypeScript/issues/24935)
-// To fix that, we create a new type with an intersection to exclude Mutation<EntityType>
-export type EntityMutation<T> = DiscriminateUnion<EntityType> & Mutation<T>;
-
+// To fix that, we add an intersection to exclude Mutation<EntityType>
 export function isMutationOfType<T extends EntityType>(classType: Constructor<T>) {
-    return function (mutation: EntityMutation<EntityType>): mutation is EntityMutation<T> {
+    return function (mutation: EntityMutation): mutation is Mutation<T> & EntityMutation {
         return mutation.original instanceof classType;
     };
 }

--- a/domain/entity/index.ts
+++ b/domain/entity/index.ts
@@ -6,7 +6,7 @@ export { Furnishing, FurnishingId } from "./Furnishing";
 export { ActionBoard, Game } from "./Game";
 
 export { isMutationOfType } from "./Mutation";
-export type { EntityType, EntityMutation } from "./Mutation";
+export type { EntityMutation, EntityType, Mutation } from "./Mutation";
 
 export { Dwarf, Player } from "./Player";
 export type { DwarfId, PlayerId } from "./Player";

--- a/domain/util/tests.ts
+++ b/domain/util/tests.ts
@@ -6,6 +6,7 @@ import {
     EntityType,
     Game,
     isMutationOfType,
+    Mutation,
     Player,
 } from "../entity";
 import { expect } from "chai";
@@ -44,15 +45,15 @@ export function buildBaseObjects(): BaseObjectsForTests {
     return { game: game, player: firstPlayer };
 }
 
-type ToVerifyOnce<T> = (check: (mutation: EntityMutation<T>) => boolean) => void;
+type ToVerifyOnce<T> = (check: (mutation: Mutation<T>) => boolean) => void;
 
 export function expectMutationsOfType<T extends EntityType>(
-    mutations: EntityMutation<EntityType>[],
+    mutations: EntityMutation[],
     classType: Constructor<T>
 ): { toVerifyOnce: ToVerifyOnce<T> } {
     const mutationsT = mutations.filter(isMutationOfType(classType));
     return {
-        toVerifyOnce: (check: (mutation: EntityMutation<T>) => boolean) => {
+        toVerifyOnce: (check: (mutation: Mutation<T>) => boolean) => {
             expect(mutationsT.filter((mutation) => check(mutation))).to.have.lengthOf(1);
         },
     };


### PR DESCRIPTION
Suite de https://github.com/BoredGamesWorkshop/caverna/pull/4 (once more)

`EntityMutation<EntityType>` was finally behaving exactly like the old `Mutation<EntityType>`

So we stop using it and we only use the intersection in the type guard